### PR TITLE
Ensure LCD text renders left aligned

### DIFF
--- a/aqualogic_mqtt/static/index.html
+++ b/aqualogic_mqtt/static/index.html
@@ -19,8 +19,9 @@
       box-shadow: inset 0 0 12px rgba(0,0,0,.7);
       min-height: 150px;
       position: relative;
+      text-align: left;
     }
-    .lcd .line { white-space: pre; font-size: 20px; line-height: 1.6; letter-spacing: .5px; min-height: 1.6em; }
+    .lcd .line { white-space: pre; font-size: 20px; line-height: 1.6; letter-spacing: .5px; min-height: 1.6em; display: block; }
     .blink { animation: blink 1s step-end infinite; text-decoration: underline; }
     @keyframes blink { 50% { opacity: .2; } }
 


### PR DESCRIPTION
## Summary
- add explicit left alignment for the simulated LCD so text stops jumping between updates
- make each LCD line a block element to maintain the left edge across varying content

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ded616c710832f8bc602f9f8dff397